### PR TITLE
feat: :memo: add support for special notes in product options

### DIFF
--- a/prisma/migrations/20250620123223_add_note_to_product_options/migration.sql
+++ b/prisma/migrations/20250620123223_add_note_to_product_options/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ProductOptionType" ADD VALUE 'note';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,7 @@ enum ProductOptionType {
   size
   ingredient
   variable
+  note
 }
 
 model ProductOption {

--- a/src/components/admin/products-tab.tsx
+++ b/src/components/admin/products-tab.tsx
@@ -8,7 +8,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import type { Product, Category, ProductOption } from "@/lib/types"
-import { PlusCircle, Pencil, Trash2, Save, X, Trash, Plus, DollarSign, Tag } from "lucide-react"
+import { PlusCircle, Pencil, Trash2, Save, X, Trash, Plus, Tag } from "lucide-react"
 import ImageUpload from "@/components/image-upload"
 import { getProducts } from "@/actions/products/get-products"
 import { getCategories } from "@/actions/categories/get-categories"
@@ -38,9 +38,20 @@ export default function ProductsTab() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
 
+  const [selectedImage, setSelectedImage] = useState<File | null>(null)
   const [currentProduct, setCurrentProduct] = useState<Product | null>(null)
   const [newOption, setNewOption] = useState<Partial<ProductOption>>({ name: "", price: 0, isAvailable: false, type: "size" })
-  const [selectedImage, setSelectedImage] = useState<File | null>(null)
+  const placeholderNewOption =
+    newOption.type === 'size'
+      ? 'Ej: Grande, Mediana...'
+      : newOption.type === 'ingredient'
+        ? 'Ej: Extra queso, tomate, lechuga...'
+        : newOption.type === 'variable'
+          ? 'Precio a confirmar por WhatsApp'
+          : newOption.type === 'note'
+            ? 'Sin cebolla, sin tomate, sin lechuga...'
+            : 'Escribe una opción...';
+
 
   const [showDeleteOptionsModal, setShowDeleteOptionsModal] = useState(false)
   const [optionToDeleteIndex, setOptionToDeleteIndex] = useState<number | null>(null)
@@ -582,25 +593,22 @@ export default function ProductsTab() {
                             onValueChange={(value) => setNewOption({ ...newOption, type: value as "size" | "ingredient" | "variable" })}
                             disabled={isSubmitting}
                           >
-                            <SelectTrigger className="w-1/3">
+                            <SelectTrigger className="w-1/2">
                               <SelectValue placeholder="Elige una opción..." />
                             </SelectTrigger>
                             <SelectContent>
 
                               <SelectItem value={"size"}>
-                                <div className="flex justify-between items-center w-full">
-                                  <span>Tamaño</span>
-                                </div>
+                                Tamaño
                               </SelectItem>
                               <SelectItem value={"ingredient"}>
-                                <div className="flex justify-between items-center w-full">
-                                  <span>Ingredientes</span>
-                                </div>
+                                Ingrediente
                               </SelectItem>
                               <SelectItem value={"variable"}>
-                                <div className="flex justify-between items-center w-full">
-                                  <span>Variable</span>
-                                </div>
+                                Variable
+                              </SelectItem>
+                              <SelectItem value={"note"}>
+                                Nota
                               </SelectItem>
                             </SelectContent>
                           </Select>
@@ -615,7 +623,7 @@ export default function ProductsTab() {
                                 id="optionName"
                                 value={newOption.name}
                                 onChange={(e) => setNewOption({ ...newOption, name: e.target.value })}
-                                placeholder="Ej: pulpo chico, pulpo grande, etc."
+                                placeholder={placeholderNewOption}
                                 disabled={isSubmitting}
                               />
                             </div>

--- a/src/components/products/product-options-multiple.tsx
+++ b/src/components/products/product-options-multiple.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { motion } from "framer-motion"
-import { Product, ProductOption } from "@/lib/types"
+import { ProductOption } from "@/lib/types"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Label } from "@/components/ui/label"
 

--- a/src/components/sidebar-cart.tsx
+++ b/src/components/sidebar-cart.tsx
@@ -39,11 +39,12 @@ export function SidebarCart() {
   }, [closeSideCart, showDeliveryModal, showSafariModal])
 
   const generateAndSendWhatsApp = async (option: "table" | "delivery") => {
+
     const items = cart.map((item) => ({
       itemId: item.product.id,
       categoryId: item.product.categoryId,
       quantity: item.quantity,
-      unitPrice: getProductTotal(item.product), // Incluye opciones en el cálculo
+      unitPrice: getProductTotal(item.product),
     }))
 
     const formData = new FormData()
@@ -77,8 +78,7 @@ export function SidebarCart() {
         const printed = new Set()
         item.product.options.forEach((opt) => {
           if (!printed.has(opt.id)) {
-            const optionTotal = (opt.price || 0) * (opt.quantity || 1)
-            messageOrder += `   - ${opt.name} (${opt.quantity}x) - $${optionTotal.toFixed(2)}\n`
+            messageOrder += `   - ${opt.name}\n`
             printed.add(opt.id)
           }
         })

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,7 +3,7 @@ export interface ProductOption {
   productId: string;
   name: string;
   price: number;
-  type: "size" | "ingredient" | "variable";
+  type: "size" | "ingredient" | "variable" | "note";
   quantity: number;
   isAvailable: boolean;
 }

--- a/src/schemas/product.schema.ts
+++ b/src/schemas/product.schema.ts
@@ -5,7 +5,7 @@ export const optionSchema = z.object({
   name: z.string().min(1).max(100),
   price: z.coerce.number().nonnegative(),
   isAvailable: z.boolean().default(true),
-  type: z.enum(["size", "ingredient", "variable"]).optional(),
+  type: z.enum(["size", "ingredient", "variable", "note"]),
   quantity: z.number().int().nonnegative().optional().default(0),
 })
 


### PR DESCRIPTION
Introduced 'note' as a new product option type for custom client instructions. Updated admin panel, types, and cart/WhatsApp flow to handle special requests like "no onions" or "extra cheese".