### PR TITLE
refactor: :construction: make email optional in User model

### DIFF
--- a/prisma/migrations/20250621210523_make_user_email_optional/migration.sql
+++ b/prisma/migrations/20250621210523_make_user_email_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "email" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,7 +78,7 @@ model User {
   id          String   @id @default(uuid())
   name        String
   phoneNumber String   @unique
-  email       String   @unique
+  email       String?  @unique
   role        Role     @default(USER)
   password    String?
   createdAt   DateTime @default(now())


### PR DESCRIPTION
Updated Prisma schema to allow users without email addresses. Supports minimal authentication flows based on phone number only.