### PR TITLE
feat :sparkles: add without_ingredient option type and update seed data

### DIFF
--- a/prisma/migrations/20251006111838_add_new_type_option_to_enum_product_option/migration.sql
+++ b/prisma/migrations/20251006111838_add_new_type_option_to_enum_product_option/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ProductOptionType" ADD VALUE 'without_ingredient';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,7 @@ enum ProductOptionType {
   variable
   note
   limited_ingredient
+  without_ingredient
 }
 
 model ProductOption {

--- a/src/components/products/product-options-modal.tsx
+++ b/src/components/products/product-options-modal.tsx
@@ -161,50 +161,51 @@ export default function ProductOptionsModal({ product, isOpen, onClose }: Produc
                   </div>
                 </div>
 
-                {/* Options for variable price */}
-                {
-                  product.groupedOptions?.variable &&
-                  <>
-                    <Alert className="mb-6 border-orange-200 bg-orange-50">
-                      <Info className="h-4 w-4 text-primary" />
-                      <AlertDescription className="text-orange-800">
-                        <div className="space-y-2">
-                          <p className="font-medium">💰 Precio variable según tamaño</p>
-                          <p className="text-sm">
-                            El precio de este producto varía dependiendo del tamaño y disponibilidad del día.
-                          </p>
-                        </div>
-                      </AlertDescription>
-                    </Alert>
+                <div className="flex flex-col gap-5">
 
-                    {/* How it works */}
-                    <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
-                      <div className="flex items-start gap-3">
-                        <MessageCircle className="h-5 w-5 text-blue-600 mt-0.5 flex-shrink-0" />
-                        <div className="space-y-2">
-                          <h4 className="font-medium text-blue-900">¿Cómo funciona?</h4>
-                          <ol className="text-sm text-blue-800 space-y-1 list-decimal list-inside">
-                            <li>Agrega el producto a tu carrito</li>
-                            <li>Realiza tu pedido por WhatsApp</li>
-                            <li>Te confirmaremos precio y disponibilidad</li>
-                          </ol>
+                  {/* Options for variable price */}
+                  {
+                    product.groupedOptions?.variable &&
+                    <>
+                      <Alert className="mb-6 border-orange-200 bg-orange-50">
+                        <Info className="h-4 w-4 text-primary" />
+                        <AlertDescription className="text-orange-800">
+                          <div className="space-y-2">
+                            <p className="font-medium">💰 Precio variable según tamaño</p>
+                            <p className="text-sm">
+                              El precio de este producto varía dependiendo del tamaño y disponibilidad del día.
+                            </p>
+                          </div>
+                        </AlertDescription>
+                      </Alert>
+
+                      {/* How it works */}
+                      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
+                        <div className="flex items-start gap-3">
+                          <MessageCircle className="h-5 w-5 text-blue-600 mt-0.5 flex-shrink-0" />
+                          <div className="space-y-2">
+                            <h4 className="font-medium text-blue-900">¿Cómo funciona?</h4>
+                            <ol className="text-sm text-blue-800 space-y-1 list-decimal list-inside">
+                              <li>Agrega el producto a tu carrito</li>
+                              <li>Realiza tu pedido por WhatsApp</li>
+                              <li>Te confirmaremos precio y disponibilidad</li>
+                            </ol>
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  </>
-                }
+                    </>
+                  }
 
-                {/* Options Selector for sizes */}
-                {
-                  product.groupedOptions?.size &&
-                  <ProductSelector
-                    options={product.groupedOptions?.size}
-                    selectedOptionId={selectedOptionId}
-                    setSelectedOptionId={setSelectedOptionId}
-                  />
-                }
+                  {/* Options Selector for sizes */}
+                  {
+                    product.groupedOptions?.size &&
+                    <ProductSelector
+                      options={product.groupedOptions?.size}
+                      selectedOptionId={selectedOptionId}
+                      setSelectedOptionId={setSelectedOptionId}
+                    />
+                  }
 
-                <div className="flex flex-col gap-5">
                   {/* Product limited Options */}
                   {
                     hasLimitedIngredientOptions && (
@@ -292,7 +293,7 @@ export default function ProductOptionsModal({ product, isOpen, onClose }: Produc
                         <Textarea
                           value={specialNote}
                           onChange={(e) => { setSpecialNote(e.target.value) }}
-                          placeholder="Ej: sin cebolla, con doble queso, bien cocido, etc."
+                          placeholder="Ej: poca cebolla, bien cocido, etc."
                           className="min-h-[80px] resize-none border-primary focus:border-secondary focus:ring-secondary"
                           maxLength={200}
                         />

--- a/src/seed/seed-init.ts
+++ b/src/seed/seed-init.ts
@@ -354,11 +354,11 @@ const initialProducts: Product[] = [
 
 // ProductOption data
 const initialProductOptions: ProductOption[] = [
-  // Hamburger with cheese (ingredients)
+  // Hamburger with cheese (ingredients extra)
   {
     id: randomUUID(),
     productId: initialProducts.find(p => p.name === 'Hamburguesa con Queso')!.id,
-    name: 'Queso extra',
+    name: 'Queso',
     price: 25,
     quantity: 0,
     isAvailable: true,
@@ -367,8 +367,8 @@ const initialProductOptions: ProductOption[] = [
   {
     id: randomUUID(),
     productId: initialProducts.find(p => p.name === 'Hamburguesa con Queso')!.id,
-    name: 'Cebolla',
-    price: 0,
+    name: 'Tocino',
+    price: 15,
     quantity: 0,
     isAvailable: true,
     type: 'ingredient'
@@ -377,25 +377,55 @@ const initialProductOptions: ProductOption[] = [
     id: randomUUID(),
     productId: initialProducts.find(p => p.name === 'Hamburguesa con Queso')!.id,
     name: 'Tomate',
-    price: 0,
+    price: 5,
     quantity: 0,
     isAvailable: true,
     type: 'ingredient'
   },
-  {
-    id: randomUUID(),
-    productId: initialProducts.find(p => p.name === 'Hamburguesa con Queso')!.id,
-    name: 'Lechuga',
-    price: 0,
-    quantity: 0,
-    isAvailable: true,
-    type: 'ingredient'
-  },
-  // Double hamburger (ingredients)
+
+  // Double hamburger (without ingredients)
   {
     id: randomUUID(),
     productId: initialProducts.find(p => p.name === 'Hamburguesa Doble')!.id,
-    name: 'Queso extra',
+    name: 'Sin queso',
+    price: 0,
+    quantity: 0,
+    isAvailable: true,
+    type: 'without_ingredient'
+  },
+  {
+    id: randomUUID(),
+    productId: initialProducts.find(p => p.name === 'Hamburguesa Doble')!.id,
+    name: 'Sin cebolla',
+    price: 0,
+    quantity: 0,
+    isAvailable: true,
+    type: 'without_ingredient'
+  },
+  {
+    id: randomUUID(),
+    productId: initialProducts.find(p => p.name === 'Hamburguesa Doble')!.id,
+    name: 'Sin tomate',
+    price: 0,
+    quantity: 0,
+    isAvailable: true,
+    type: 'without_ingredient'
+  },
+  {
+    id: randomUUID(),
+    productId: initialProducts.find(p => p.name === 'Hamburguesa Doble')!.id,
+    name: 'Sin lechuga',
+    price: 0,
+    quantity: 0,
+    isAvailable: true,
+    type: 'without_ingredient'
+  },
+
+  // Double hamburger (ingredients extra)
+  {
+    id: randomUUID(),
+    productId: initialProducts.find(p => p.name === 'Hamburguesa Doble')!.id,
+    name: 'Queso',
     price: 25,
     quantity: 0,
     isAvailable: true,
@@ -404,8 +434,8 @@ const initialProductOptions: ProductOption[] = [
   {
     id: randomUUID(),
     productId: initialProducts.find(p => p.name === 'Hamburguesa Doble')!.id,
-    name: 'Cebolla',
-    price: 0,
+    name: 'Tocino',
+    price: 15,
     quantity: 0,
     isAvailable: true,
     type: 'ingredient'
@@ -413,17 +443,8 @@ const initialProductOptions: ProductOption[] = [
   {
     id: randomUUID(),
     productId: initialProducts.find(p => p.name === 'Hamburguesa Doble')!.id,
-    name: 'Tomate',
-    price: 0,
-    quantity: 0,
-    isAvailable: true,
-    type: 'ingredient'
-  },
-  {
-    id: randomUUID(),
-    productId: initialProducts.find(p => p.name === 'Hamburguesa Doble')!.id,
-    name: 'Lechuga',
-    price: 0,
+    name: 'Tomate extra',
+    price: 5,
     quantity: 0,
     isAvailable: true,
     type: 'ingredient'
@@ -456,7 +477,45 @@ const initialProductOptions: ProductOption[] = [
     quantity: 0,
     isAvailable: true,
     type: 'limited_ingredient'
+  },
 
+  {
+    id: randomUUID(),
+    productId: initialProducts.find(p => p.name === 'Hamburguesa Doble')!.id,
+    name: 'Chicas',
+    price: 25,
+    quantity: 0,
+    isAvailable: true,
+    type: 'size'
+  },
+  {
+    id: randomUUID(),
+    productId: initialProducts.find(p => p.name === 'Hamburguesa Doble')!.id,
+    name: 'Medianas',
+    price: 45,
+    quantity: 0,
+    isAvailable: true,
+    type: 'size'
+  },
+  {
+    id: randomUUID(),
+    productId: initialProducts.find(p => p.name === 'Hamburguesa Doble')!.id,
+    name: 'Grandes',
+    price: 65,
+    quantity: 0,
+    isAvailable: true,
+    type: 'size'
+  },
+
+  // Double hamburger (note)
+  {
+    id: randomUUID(),
+    productId: initialProducts.find(p => p.name === 'Hamburguesa Doble')!.id,
+    name: 'Notas',
+    price: 0,
+    quantity: 0,
+    isAvailable: true,
+    type: 'note'
   },
 
   // Hawaiian hamburger (limited ingredients)


### PR DESCRIPTION
- Added `without_ingredient` to `ProductOptionType` in Prisma schema
- Updated product options modal with better layout and cleaner placeholders
- Adjusted seed data for hamburgers:
  - Replaced/renamed extras and ingredients (Queso, Tocino, Tomate extra)
  - Added "sin ingrediente" options for double hamburger
  - Introduced size options (Chicas, Medianas, Grandes)
  - Added note option for custom instructions