### PR TITLE
Feat/product options modal improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ diff.txt
 
 # Postgres
 /postgres
+
+# Excalidraw
+*.excalidraw

--- a/src/components/products/product-options-modal.tsx
+++ b/src/components/products/product-options-modal.tsx
@@ -205,7 +205,6 @@ export default function ProductOptionsModal({ product, isOpen, onClose }: Produc
                       options={product.groupedOptions?.size}
                       selectedOptionId={selectedOptionId}
                       setSelectedOptionId={setSelectedOptionId}
-                      isOpen={isOpen}
                       title='Selecciona un tamaño:'
                     />
                   }

--- a/src/components/products/product-options-modal.tsx
+++ b/src/components/products/product-options-modal.tsx
@@ -73,6 +73,7 @@ export default function ProductOptionsModal({ product, isOpen, onClose }: Produc
     onClose()
     setSelectedOptionId('')
     setSelectedExtraIds([])
+    setSelectedWithoutIds([])
     setSelectedLimitedOptionIds([])
     setQuantity(1)
   }
@@ -81,6 +82,7 @@ export default function ProductOptionsModal({ product, isOpen, onClose }: Produc
     onClose()
     setSelectedOptionId('')
     setSelectedExtraIds([])
+    setSelectedWithoutIds([])
     setSelectedLimitedOptionIds([])
     setQuantity(1)
   }
@@ -203,6 +205,8 @@ export default function ProductOptionsModal({ product, isOpen, onClose }: Produc
                       options={product.groupedOptions?.size}
                       selectedOptionId={selectedOptionId}
                       setSelectedOptionId={setSelectedOptionId}
+                      isOpen={isOpen}
+                      title='Selecciona un tamaño:'
                     />
                   }
 

--- a/src/components/products/product-selector.tsx
+++ b/src/components/products/product-selector.tsx
@@ -5,7 +5,6 @@ interface ProductSelectorProps {
   options: ProductOption[]
   selectedOptionId: string
   setSelectedOptionId: React.Dispatch<React.SetStateAction<string>>
-  isOpen: boolean
   title: string
 }
 

--- a/src/components/products/product-selector.tsx
+++ b/src/components/products/product-selector.tsx
@@ -5,18 +5,21 @@ interface ProductSelectorProps {
   options: ProductOption[]
   selectedOptionId: string
   setSelectedOptionId: React.Dispatch<React.SetStateAction<string>>
+  isOpen: boolean
+  title: string
 }
 
 const ProductSelector = ({
   options,
   selectedOptionId,
-  setSelectedOptionId
+  setSelectedOptionId,
+  title
 }: ProductSelectorProps) => {
   return (
     <div className="space-y-4">
       {/* Options Select */}
       <div>
-        {/* <h4 className="font-medium mb-2">Selecciona un tamaño:</h4> */}
+        <h4 className="font-medium mb-2">{title}</h4>
         <Select value={selectedOptionId} onValueChange={setSelectedOptionId}>
           <SelectTrigger className="w-full">
             <SelectValue placeholder="Elige una opción..." />


### PR DESCRIPTION
feat :sparkles: Add ProductOptionsModal reset and selector title

Enhance ProductOptionsModal by resetting `selectedWithoutIds` on close and passing `title` props to ProductSelector for better configurability and dynamic headings.

- Reset `selectedWithoutIds` when modal closes
- Update ProductSelector to display dynamic title
- Add *.excalidraw to .gitignore to ignore Excalidraw files

Closes modal reset issues and improves option selector flexibility.