### PR TITLE
refactor: 🎨 improve maps UX and defaults

### DIFF
--- a/src/components/maps/google-maps.tsx
+++ b/src/components/maps/google-maps.tsx
@@ -17,6 +17,7 @@ export const GoogleMaps = ({ isOpen, onLocationChange, moveToLocation, initialLo
   const mapInstanceRef = useRef<google.maps.Map | null>(null)
   const markerRef = useRef<google.maps.marker.AdvancedMarkerElement | null>(null)
 
+  // Function to reverse geocode coordinates to address
   // reverse geocode helper
   const reverseGeocode = async (lat: number, lng: number) => {
     if (!geocoderRef.current) return
@@ -86,8 +87,8 @@ export const GoogleMaps = ({ isOpen, onLocationChange, moveToLocation, initialLo
 
         const hasInitialLocation = initialLocation?.lat !== 0 && initialLocation?.lng !== 0
 
-        // location Taco Madre
-        const defaultLocation = { lat: 19.8675683, lng: -90.4926057 }
+        // location default
+        const defaultLocation = { lat: 19.8491608, lng: -90.5344815 }
 
         // Set initial location
         // If moveToLocation → priority
@@ -155,6 +156,6 @@ export const GoogleMaps = ({ isOpen, onLocationChange, moveToLocation, initialLo
   }, [isOpen])
 
   return (
-    <div ref={mapRef} className="w-full h-full" />
+    <div ref={mapRef} className='w-full h-full' />
   )
 }

--- a/src/components/maps/location-picker.tsx
+++ b/src/components/maps/location-picker.tsx
@@ -33,9 +33,7 @@ export function LocationPicker({ isOpen, onClose, onConfirmLocation, initialAddr
 
   const getCurrentLocation = () => {
     if (!navigator.geolocation) {
-      toast.error('Geolocalización no disponible', {
-        duration: 1200
-      })
+      toast.error('Geolocalización no disponible', { position: 'top-right' })
       return
     }
 
@@ -50,9 +48,7 @@ export function LocationPicker({ isOpen, onClose, onConfirmLocation, initialAddr
       (error) => {
         console.error('Geolocation error:', error)
         setIsLoading(false)
-        toast.error('No se pudo obtener la ubicación actual', {
-          duration: 1200
-        })
+        toast.error('No se pudo obtener la ubicación actual', { position: 'top-right' })
       },
       {
         enableHighAccuracy: true,
@@ -66,22 +62,16 @@ export function LocationPicker({ isOpen, onClose, onConfirmLocation, initialAddr
     setSelectedLocation({ address, lat, lng })
     // Clear the trigger after processing
     setMoveToLocation(null)
-    toast.success('Ubicación encontrada', {
-      duration: 1200
-    })
+    toast.success('Ubicación encontrada', { position: 'top-right' })
   }
 
   const handleSave = () => {
     if (selectedLocation) {
       onConfirmLocation(selectedLocation.address, selectedLocation.lat, selectedLocation.lng)
-      toast.success('Ubicación guardada', {
-        duration: 1200
-      })
+      toast.success('Ubicación guardada', { position: 'top-right' })
       onClose()
     } else {
-      toast.error('Selecciona una ubicación en el mapa', {
-        duration: 1200
-      })
+      toast.error('Selecciona una ubicación en el mapa', { position: 'top-right' })
     }
   }
 
@@ -144,7 +134,7 @@ export function LocationPicker({ isOpen, onClose, onConfirmLocation, initialAddr
         </div>
 
         <DialogFooter className="flex flex-col gap-2 sm:flex-row">
-          <Button variant="outline" onClick={handleCancel} className="w-full sm:w-auto bg-transparent">
+          <Button variant="destructive" onClick={handleCancel} className="w-full sm:w-auto">
             Cancelar
           </Button>
           <Button

--- a/src/components/sidebar-cart.tsx
+++ b/src/components/sidebar-cart.tsx
@@ -153,7 +153,9 @@ export function SidebarCart() {
       messageOrder += `📞 *Teléfono:* ${deliveryForm.receiverPhone}\n`
       messageOrder += `💳 *Pago:* ${capitalizeWords(deliveryForm.paymentMethod)}\n\n`
 
-      messageOrder += '¡Gracias por tu pedido! Por favor, presiona el botón de enviar mensaje para continuar.'
+      messageOrder += deliveryForm.coordinates.lat !== 0
+        ? '¡Gracias por tu pedido! Por favor, presiona el botón de enviar mensaje para continuar.'
+        : '¡Gracias por tu pedido! Por favor, presiona el botón de enviar mensaje para continuar y, seguido compártenos tu ubicación para que podamos enviarte tu pedido.'
     }
 
     const encodedMessage = encodeURIComponent(messageOrder)
@@ -604,7 +606,7 @@ export function SidebarCart() {
                   autoComplete='nope'
                 />
 
-                <div className="border rounded-md py-4 px-2">
+                <div className="py-4 px-0">
                   <div className='flex items-center gap-2 justify-between'>
                     <h2 className="font-normal text-sm mb-1">Ubicación</h2>
                     <Badge className="text-[10px]">
@@ -645,10 +647,20 @@ export function SidebarCart() {
                   placeholder="Dirección completa"
                   value={deliveryForm.address}
                   onChange={(e) => {
-                    setDeliveryForm({
-                      ...deliveryForm,
-                      address: e.target.value
-                    })
+                    const newAddress = e.target.value
+                    if (hasLocation && newAddress !== deliveryForm.address) {
+                      setDeliveryForm({
+                        ...deliveryForm,
+                        address: newAddress,
+                        coordinates: { lat: 0, lng: 0 }
+                      })
+                      toast.info('Ubicación del mapa reiniciada al editar manualmente', {
+                        description: 'Vuelve a seleccionar en el mapa si deseas enviar tu ubicación exacta.',
+                        position: 'top-right'
+                      })
+                    } else {
+                      setDeliveryForm({ ...deliveryForm, address: newAddress })
+                    }
                   }}
                   className="w-full p-2 rounded border text-sm"
                   autoComplete='nope'


### PR DESCRIPTION
### Changes Made
- refactor: 🗺️ update default map coordinates
- style: 💄 standardize toast position top-right
- refactor: 🔁 improve address reset logic
- style: 🎨 simplify location container styles
- style: 🔴 use destructive variant for cancel
- fix: 🧭 adjust WhatsApp message fallback text

### Description of Changes
- Updated the default map center coordinates to reflect the new base location instead of the previous hardcoded branch reference.
- Standardized all map-related toast notifications to use `position: 'top-right'` for UI consistency and removed custom duration overrides.
- Improved delivery address handling in the sidebar cart: when a user edits the address manually after selecting a map location, the stored coordinates are now reset and an informational toast explains the behavior to prevent mismatched address/coordinates.
- Adjusted the WhatsApp confirmation message to dynamically request location sharing only when coordinates are missing.
- Simplified layout styles in the location section by removing unnecessary borders and aligning spacing.
- Updated the cancel button in `LocationPicker` to use the `destructive` variant for clearer visual intent.

These changes enhance UX clarity, prevent inconsistent delivery data, and standardize notification behavior across the maps flow.